### PR TITLE
Refactor global state and callback to support Swift build

### DIFF
--- a/Sources/Wintund/ClockCleaner.swift
+++ b/Sources/Wintund/ClockCleaner.swift
@@ -1,12 +1,12 @@
 import Foundation
 import AppKit
-import ApplicationServices
+@preconcurrency import ApplicationServices
 import CoreGraphics
 import Dispatch
 
 @MainActor func isClockHit(at point: CGPoint) -> Bool {
     var element: AXUIElement?
-    let res = AXUIElementCopyElementAtPosition(systemWide, Float(point.x), Float(point.y), &element)
+    let res = AXUIElementCopyElementAtPosition(Globals.systemWide, Float(point.x), Float(point.y), &element)
     guard res == .success, let hit = element else { return false }
     var current: AXUIElement? = hit
     var depth = 0
@@ -46,7 +46,7 @@ import Dispatch
 @MainActor func clockRightMouseDown(_ event: CGEvent) -> Unmanaged<CGEvent>? {
     let loc = event.location
     if isClockHit(at: loc) {
-        swallowNextMouseUp = true
+        Globals.swallowNextMouseUp = true
         DispatchQueue.global(qos: .userInitiated).async { cleanDesktop() }
         return nil
     }

--- a/Sources/Wintund/CloseButtonMinimizer.swift
+++ b/Sources/Wintund/CloseButtonMinimizer.swift
@@ -1,6 +1,6 @@
 import Foundation
 import AppKit
-import ApplicationServices
+@preconcurrency import ApplicationServices
 import CoreGraphics
 import Dispatch
 
@@ -60,7 +60,7 @@ func minimizeWindow(_ win: AXUIElement) -> Bool {
     let loc = event.location
     if let el = elementAtPoint(loc), let closeEl = findCloseButtonAncestor(el), let win = ancestorWindow(from: closeEl) {
         if minimizeWindow(win) {
-            swallowNextUp = true
+            Globals.swallowNextUp = true
             return nil
         }
     }

--- a/Sources/Wintund/EventCallback.swift
+++ b/Sources/Wintund/EventCallback.swift
@@ -1,37 +1,38 @@
 import Foundation
 import AppKit
-import ApplicationServices
+@preconcurrency import ApplicationServices
 import CoreGraphics
 import Dispatch
 
 @MainActor
+@convention(c)
 func eventCallback(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refcon: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>? {
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-        if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
+        if let tap = Globals.eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
         return Unmanaged.passUnretained(event)
     }
     if type == .leftMouseDown {
-        if globalConfig.enableCloseMinimizer {
+        if Globals.globalConfig.enableCloseMinimizer {
             if handleLeftMouseDown(event) == nil { return nil }
         }
-        if globalConfig.enableGreenZoom {
+        if Globals.globalConfig.enableGreenZoom {
             if greenZoomLeftMouseDown(event) == nil { return nil }
         }
         return Unmanaged.passUnretained(event)
     }
     if type == .leftMouseUp {
-        if swallowNextUp { swallowNextUp = false; return nil }
-        if swallowMouseUp { swallowMouseUp = false; return nil }
+        if Globals.swallowNextUp { Globals.swallowNextUp = false; return nil }
+        if Globals.swallowMouseUp { Globals.swallowMouseUp = false; return nil }
         return Unmanaged.passUnretained(event)
     }
     if type == .rightMouseDown {
-        if globalConfig.enableClockCleaner {
+        if Globals.globalConfig.enableClockCleaner {
             if clockRightMouseDown(event) == nil { return nil }
         }
         return Unmanaged.passUnretained(event)
     }
     if type == .rightMouseUp {
-        if swallowNextMouseUp { swallowNextMouseUp = false; return nil }
+        if Globals.swallowNextMouseUp { Globals.swallowNextMouseUp = false; return nil }
         return Unmanaged.passUnretained(event)
     }
     return Unmanaged.passUnretained(event)

--- a/Sources/Wintund/Globals.swift
+++ b/Sources/Wintund/Globals.swift
@@ -1,12 +1,18 @@
 import Foundation
 import AppKit
-import ApplicationServices
+@preconcurrency import ApplicationServices
 import CoreGraphics
 import Dispatch
 
-@MainActor var eventTap: CFMachPort?
-@MainActor var swallowNextUp = false
-@MainActor var swallowMouseUp = false
-@MainActor var swallowNextMouseUp = false
-@MainActor var systemWide: AXUIElement!
-@MainActor var globalConfig: Config!
+enum Globals {
+    @MainActor static var eventTap: CFMachPort?
+    @MainActor static var swallowNextUp = false
+    @MainActor static var swallowMouseUp = false
+    @MainActor static var swallowNextMouseUp = false
+    @MainActor static var systemWide: AXUIElement!
+    @MainActor static var globalConfig: Config!
+    @MainActor static var origTile: Float = 0
+    @MainActor static var origOrient: Int32 = 0
+    @MainActor static var origPin: Int32 = 0
+    @MainActor static var changedPin = false
+}

--- a/Sources/Wintund/GreenZoom.swift
+++ b/Sources/Wintund/GreenZoom.swift
@@ -1,6 +1,6 @@
 import Foundation
 import AppKit
-import ApplicationServices
+@preconcurrency import ApplicationServices
 import CoreGraphics
 import Dispatch
 
@@ -26,13 +26,13 @@ func synthesizeAltClick(at p: CGPoint) {
     if event.flags.contains(.maskAlternate) { return Unmanaged.passUnretained(event) }
     let loc = event.location
     var elem: AXUIElement?
-    _ = AXUIElementCopyElementAtPosition(systemWide, Float(loc.x), Float(loc.y), &elem)
+    _ = AXUIElementCopyElementAtPosition(Globals.systemWide, Float(loc.x), Float(loc.y), &elem)
     if let e = elem, stringAttr(e, kAXSubroleAttribute as CFString) == "AXFullScreenButton" {
         if let win = enclosingWindow(of: e), performFill(on: win) {
-            swallowMouseUp = true
+            Globals.swallowMouseUp = true
             return nil
         }
-        swallowMouseUp = true
+        Globals.swallowMouseUp = true
         synthesizeAltClick(at: loc)
         return nil
     }

--- a/Sources/Wintund/main.swift
+++ b/Sources/Wintund/main.swift
@@ -1,6 +1,6 @@
 import Foundation
 import AppKit
-import ApplicationServices
+@preconcurrency import ApplicationServices
 import CoreGraphics
 import Dispatch
 
@@ -8,8 +8,8 @@ import Dispatch
 @MainActor
 struct Main {
     static func main() {
-        systemWide = AXUIElementCreateSystemWide()
-        globalConfig = loadConfig(path: {
+        Globals.systemWide = AXUIElementCreateSystemWide()
+        Globals.globalConfig = loadConfig(path: {
             var p: String?
             var it = CommandLine.arguments.makeIterator()
             _ = it.next()
@@ -25,8 +25,8 @@ struct Main {
             (CGEventMask(1) << CGEventType.leftMouseUp.rawValue) |
             (CGEventMask(1) << CGEventType.rightMouseDown.rawValue) |
             (CGEventMask(1) << CGEventType.rightMouseUp.rawValue)
-        eventTap = CGEvent.tapCreate(tap: .cghidEventTap, place: .headInsertEventTap, options: .defaultTap, eventsOfInterest: mask, callback: eventCallback, userInfo: nil)
-        if let tap = eventTap {
+        Globals.eventTap = CGEvent.tapCreate(tap: .cghidEventTap, place: .headInsertEventTap, options: .defaultTap, eventsOfInterest: mask, callback: eventCallback, userInfo: nil)
+        if let tap = Globals.eventTap {
             let src = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
             CFRunLoopAddSource(CFRunLoopGetCurrent(), src, .commonModes)
             CGEvent.tapEnable(tap: tap, enable: true)


### PR DESCRIPTION
## Summary
- Replace top-level variables with Globals enum to comply with @main restrictions
- Expose CGEvent tap callback with @convention(c) and use new Globals store
- Update imports and Dock state management

## Testing
- `./build.sh` *(fails: no such module 'AppKit')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a071b08832d8bf6aae6a45d265d