### PR TITLE
Enforce permissions and add reusable build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: build
+on:
+  workflow_call:
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.*'
+      - run: ./build.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wintund
+          path: build/wintund.tar.gz

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ The Prosperity Public License 3.0.0
 
 Contributor: Denis Kudelin
 
-Source Code: https://github.com/Itexoft/Keystone4NET
+Source Code: https://github.com/Itexoft/wintund
 
 Purpose
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Swift utility providing desktop tweaks for macOS.
 
 Edit `config.ini` next to the executable to enable or disable tweaks and adjust parameters.
 
+## Permissions
+
+The application requires Accessibility and Input Monitoring permissions.
+
 ## Build
 
 ```

--- a/Sources/Wintund/AXUtilities.swift
+++ b/Sources/Wintund/AXUtilities.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AppKit
 @preconcurrency import ApplicationServices
 @preconcurrency import CoreGraphics
 

--- a/Sources/Wintund/CloseButtonMinimizer.swift
+++ b/Sources/Wintund/CloseButtonMinimizer.swift
@@ -1,4 +1,3 @@
-import Foundation
 @preconcurrency import ApplicationServices
 @preconcurrency import CoreGraphics
 import AppKit

--- a/Sources/Wintund/Config.swift
+++ b/Sources/Wintund/Config.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AppKit
 
 struct Ini { var sections: [String: [String: String]] }
 

--- a/Sources/Wintund/EventCallback.swift
+++ b/Sources/Wintund/EventCallback.swift
@@ -1,5 +1,3 @@
-import Foundation
-import AppKit
 @preconcurrency import ApplicationServices
 @preconcurrency import CoreGraphics
 

--- a/Sources/Wintund/Globals.swift
+++ b/Sources/Wintund/Globals.swift
@@ -1,7 +1,4 @@
-import Foundation
-import AppKit
 @preconcurrency import ApplicationServices
-@preconcurrency import CoreGraphics
 
 @MainActor
 enum Globals {

--- a/Sources/Wintund/GreenZoom.swift
+++ b/Sources/Wintund/GreenZoom.swift
@@ -1,4 +1,3 @@
-import AppKit
 @preconcurrency import ApplicationServices
 @preconcurrency import CoreGraphics
 

--- a/Sources/Wintund/Main.swift
+++ b/Sources/Wintund/Main.swift
@@ -1,14 +1,19 @@
 import Foundation
-import AppKit
 @preconcurrency import ApplicationServices
 @preconcurrency import CoreGraphics
-import Dispatch
 
 @main
 struct Main {
     @MainActor static func main() {
         let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as CFString
-        _ = AXIsProcessTrustedWithOptions([key: true] as CFDictionary)
+        guard AXIsProcessTrustedWithOptions([key: true] as CFDictionary) else {
+            fputs("accessibility permission missing\n", stderr)
+            exit(1)
+        }
+        if !CGPreflightListenEventAccess() && !CGRequestListenEventAccess() {
+            fputs("input monitoring permission missing\n", stderr)
+            exit(1)
+        }
         let mask: CGEventMask =
             (CGEventMask(1) << CGEventType.leftMouseDown.rawValue) |
             (CGEventMask(1) << CGEventType.leftMouseUp.rawValue)


### PR DESCRIPTION
## Summary
- ensure the app exits when Accessibility or Input Monitoring permissions are missing
- prune unused imports and document required permissions
- add reusable build workflow for releases and fix license link

## Testing
- `swift build` *(fails: no such module 'ApplicationServices')*
- `./build.sh` *(fails: macOS required)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9bd1f61c832d80fa76f7fb931066