### PR TITLE
Add debug mode and streamline build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,25 +6,12 @@
      platforms: [
          .macOS(.v10_15)
      ],
-     products: [
-         .executable(name: "wintund", targets: ["Wintund"])
-     ],
-     targets: [
-         .executableTarget(
-             name: "Wintund",
-             linkerSettings: [
-                 .linkedFramework("AppKit"),
-                 .linkedFramework("ApplicationServices"),
-                 .linkedFramework("CoreGraphics"),
-                 .unsafeFlags([
-                     "-Xlinker", "-U", "-Xlinker", "_CoreDockGetTileSize",
-                     "-Xlinker", "-U", "-Xlinker", "_CoreDockSetTileSize",
-                     "-Xlinker", "-U", "-Xlinker", "_CoreDockGetRect",
-                     "-Xlinker", "-U", "-Xlinker", "_CoreDockGetOrientationAndPinning",
-                     "-Xlinker", "-U", "-Xlinker", "_CoreDockSetOrientationAndPinning",
-                     "-Xlinker", "-U", "-Xlinker", "_CoreDockSetAutoHideEnabled"
-                 ])
-             ]
-         )
-     ]
- )
+    products: [
+        .executable(name: "wintund", targets: ["Wintund"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "Wintund"
+        )
+    ]
+)

--- a/Sources/Wintund/Main.swift
+++ b/Sources/Wintund/Main.swift
@@ -5,23 +5,36 @@ import Foundation
 @main
 struct Main {
     @MainActor static func main() {
+        let debug = CommandLine.arguments.contains("--debug")
+        if debug { print("debug start") }
         let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as CFString
         guard AXIsProcessTrustedWithOptions([key: true] as CFDictionary) else {
             fputs("accessibility permission missing\n", stderr)
             exit(1)
         }
+        if debug { print("debug accessibility") }
         if !CGPreflightListenEventAccess() && !CGRequestListenEventAccess() {
             fputs("input monitoring permission missing\n", stderr)
             exit(1)
         }
+        if debug { print("debug input monitoring") }
         let mask: CGEventMask =
             (CGEventMask(1) << CGEventType.leftMouseDown.rawValue) |
             (CGEventMask(1) << CGEventType.leftMouseUp.rawValue)
         Globals.eventTap = CGEvent.tapCreate(tap: .cghidEventTap, place: .headInsertEventTap, options: .defaultTap, eventsOfInterest: mask, callback: eventCallback, userInfo: nil)
         guard let tap = Globals.eventTap else { fputs("failed to create event tap\n", stderr); exit(1) }
+        if debug { print("debug event tap") }
         let src = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         CFRunLoopAddSource(CFRunLoopGetCurrent(), src, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
+        if debug {
+            if let e = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: .zero, mouseButton: .left) {
+                let r = handleEvent(type: .leftMouseDown, event: e)
+                if r == nil { print("debug handler nil") } else { print("debug handler ok") }
+            } else {
+                print("debug event fail")
+            }
+        }
         CFRunLoopRun()
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 2
 fi
 BUILD_DIR="$(pwd)/build"
-swift build -c release
+swift build -c release --arch arm64
 mkdir -p "$BUILD_DIR"
 cp .build/release/wintund "$BUILD_DIR"/
 cp config.ini "$BUILD_DIR"/


### PR DESCRIPTION
## Summary
- Drop unused linker flags and frameworks
- Add `--debug` mode with stdout logging and self-test
- Build arm64-only release

## Testing
- `swift build -c release --arch arm64` *(fails: could not find module '_Concurrency' for target 'arm64-unknown-linux-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68aaa2039828832d9d401fc37b643f2d