### PR TITLE
Detect window for clicked close button

### DIFF
--- a/Sources/Wintund/AXUtilities.swift
+++ b/Sources/Wintund/AXUtilities.swift
@@ -78,6 +78,12 @@ func findCloseButtonAncestor(_ el: AXUIElement) -> AXUIElement? {
 }
 
 @MainActor
+func windowForCloseButton(_ el: AXUIElement) -> AXUIElement? {
+    if let w = attributeElement(el, kAXWindowAttribute as CFString) { return w }
+    return ancestorWindow(from: el)
+}
+
+@MainActor
 func enclosingWindow(of e: AXUIElement) -> AXUIElement? {
     var cur: AXUIElement? = e
     var guardCount = 0

--- a/Sources/Wintund/CloseButtonMinimizer.swift
+++ b/Sources/Wintund/CloseButtonMinimizer.swift
@@ -50,7 +50,7 @@ func hideApp(for win: AXUIElement) -> Bool {
 @MainActor
 func handleLeftMouseDown(_ event: CGEvent) -> Unmanaged<CGEvent>? {
     let loc = event.location
-    if let el = elementAtPoint(loc), let closeEl = findCloseButtonAncestor(el), let win = ancestorWindow(from: closeEl) {
+    if let el = elementAtPoint(loc), let closeEl = findCloseButtonAncestor(el), let win = windowForCloseButton(closeEl) {
         if isSeriousWindow(win) {
             if hideApp(for: win) { Globals.swallowNextUp = true; return nil }
         }


### PR DESCRIPTION
## Summary
- Resolve the close button to its own window before classification
- Use that window when deciding whether to hide an app

## Testing
- `/root/osx-run/osx-run.sh swift build` *(fails: clang: error: no such file or directory: '/opt/osxcross/target/SDK/MacOSX15.5.sdk/usr/lib/swift/linux/x86_64/swiftrt.o')*

------
https://chatgpt.com/codex/tasks/task_e_68af16db714c832d8a0a40fe5e900529